### PR TITLE
Setup properties request

### DIFF
--- a/src/main/scala/com.gu.conf/ConfigurationFactory.scala
+++ b/src/main/scala/com.gu.conf/ConfigurationFactory.scala
@@ -32,4 +32,19 @@ object ConfigurationFactory {
   def getConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
     (new GuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
   }
+
+  def getConfiguration(applicationName: String, webappConfDirectory: String, intServiceDomain: String, stage: String): Configuration = {
+    setSystemProperties(intServiceDomain, stage)
+    getConfiguration(applicationName, webappConfDirectory)
+  }
+
+  def getConfiguration(applicationName: String, intServiceDomain: String, stage: String): Configuration = {
+    setSystemProperties(intServiceDomain, stage)
+    getConfiguration(applicationName)
+  }
+
+  private def setSystemProperties(intServiceDomain: String, stage: String) {
+    System.setProperty("int.service.domain", intServiceDomain)
+    System.setProperty("stage", stage)
+  }
 }

--- a/src/main/scala/com.gu.conf/impl/SetupConfiguration.scala
+++ b/src/main/scala/com.gu.conf/impl/SetupConfiguration.scala
@@ -28,11 +28,14 @@ private[conf] class SetupConfiguration(
   val properties = loader getPropertiesFrom SETUP_PROPERTIES_LOCATION
 
   val setup = new PropertiesBasedConfiguration(SETUP_PROPERTIES_LOCATION, properties)
+  val systemSetup = new SystemPropertiesConfiguration()
 
   def getIdentifier: String = "Setup"
 
   def getServiceDomain: String = {
-    getStringProperty("int.service.domain") orElse
+    getSystemProperty("int.service.domain") orElse
+      getSystemProperty("INT_SERVICE_DOMAIN") orElse
+      getStringProperty("int.service.domain") orElse
       getStringProperty("INT_SERVICE_DOMAIN") getOrElse {
         LOG.info("unable to find INT_SERVICE_DOMAIN in " + SETUP_PROPERTIES_LOCATION + " defaulting to \"default\"")
         "default"
@@ -40,7 +43,9 @@ private[conf] class SetupConfiguration(
   }
 
   def getStage: String = {
-    getStringProperty("stage") orElse
+    getSystemProperty("stage") orElse
+      getSystemProperty("STAGE") orElse
+      getStringProperty("stage") orElse
       getStringProperty("STAGE") getOrElse {
         LOG.info("unable to find STAGE in " + SETUP_PROPERTIES_LOCATION + " defaulting to \"default\"")
         "default"
@@ -55,7 +60,13 @@ private[conf] class SetupConfiguration(
     setup.getStringProperty(propertyName)
   }
 
-  def getPropertyNames: Set[String] = setup.getPropertyNames
+  def getSystemProperty(propertyName: String): Option[String] = {
+    systemSetup.getStringProperty(propertyName)
+  }
+
+  def getPropertyNames: Set[String] = {
+    setup.getPropertyNames ++ systemSetup.getPropertyNames
+  }
 
   def getEnvironmentVariables: Map[String, String] = {
     import scala.collection.JavaConversions._

--- a/src/main/scala/com.gu.conf/impl/SystemConfigurations.scala
+++ b/src/main/scala/com.gu.conf/impl/SystemConfigurations.scala
@@ -27,5 +27,10 @@ private[conf] class SystemEnvironmentConfiguration(
   private val _properties: Map[String, String] = SystemEnvironmentConfiguration.environment) extends MapBasedConfiguration(_identifier, _properties)
 
 private[conf] class SystemPropertiesConfiguration(
-  private val _identifier: String = "System",
-  private val _properties: Properties = System.getProperties) extends PropertiesBasedConfiguration(_identifier, _properties)
+    private val _identifier: String = "System",
+    private val _properties: Properties = System.getProperties) extends PropertiesBasedConfiguration(_identifier, _properties) {
+
+  override def getStringProperty(propertyName: String): Option[String] = {
+    properties.get(propertyName)
+  }
+}

--- a/src/test/scala/com.gu.conf/impl/SetupConfigurationTest.scala
+++ b/src/test/scala/com.gu.conf/impl/SetupConfigurationTest.scala
@@ -39,10 +39,10 @@ class SetupConfigurationTest extends FunSuite with ShouldMatchers with MockitoSu
     new SetupConfiguration(loader)
   }
 
-  test("should not return the value of the int service domain system property if set") {
+  test("should return the value of the int service domain system property if set") {
     try {
       System.setProperty("int.service.domain", "myintservicedomain")
-      installationConfiguration().getServiceDomain should be("default")
+      installationConfiguration().getServiceDomain should be("myintservicedomain")
     } finally {
       System.clearProperty("int.service.domain")
     }
@@ -55,10 +55,10 @@ class SetupConfigurationTest extends FunSuite with ShouldMatchers with MockitoSu
     configuration.getServiceDomain should be("myservicedomain")
   }
 
-  test("should not return the stage from system property if set") {
+  test("should return the stage from system property if set") {
     try {
       System.setProperty("stage", "SYSTEMPROPERTYSTAGE")
-      installationConfiguration().getStage should be("default")
+      installationConfiguration().getStage should be("SYSTEMPROPERTYSTAGE")
     } finally {
       System.clearProperty("stage")
     }


### PR DESCRIPTION
Using the system properties for stage and int.service.domain (if set) before checking the properties based configuration.

I did this work so that developers can specify which environment to run up as in R2. However as this forces the local box to point to the different environment it messes up the layout etc, so I shall take a different approach. 

This branch may be of some use in the future.
