### PR TITLE
More helpful error message when property is missing

### DIFF
--- a/src/main/scala/com.gu.conf/Configuration.scala
+++ b/src/main/scala/com.gu.conf/Configuration.scala
@@ -60,7 +60,8 @@ trait Configuration {
    * @throws java.util.NoSuchElementException if property has not been set
    */
   def apply(propertyName: String): String = {
-    getStringProperty(propertyName).get
+    getStringProperty(propertyName)
+     .getOrElse(sys.error("Required configuration property is missing: " + propertyName))
   }
 
   /**


### PR DESCRIPTION
Because just seeing `NoSuchElementException` in the stack trace isn't terribly useful.
