### PR TITLE
Now supports Scala 2.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .idea
 project/boot
 project/plugins/boot
+.vagrant

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Framework support for a standard webapp configuration scheme.
 
 ## Building it ##
 
-* Ensure you have SBT installed, we recommend 0.11.3-2 for maximum backward compatibility
+* Ensure you have SBT installed, we recommend 0.13.5
 
+## Compatibility  ##
+
+* Latest version 4.0 for Scala 2.10 & 2.11
 
 ## Guiding Principles ##
 

--- a/VagrantFile
+++ b/VagrantFile
@@ -1,0 +1,17 @@
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.provision :shell, :path => "provision.sh"
+
+  config.vm.box = 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+  config.vm.synced_folder "~/.ivy2", "/home/vagrant/.ivy2"
+
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--memory", "3064"]
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "80"]
+  end
+
+end

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,13 @@ name := "configuration"
 
 organization := "com.gu"
 
-scalaVersion := "2.10.0"
+scalaVersion in ThisBuild := "2.11.2"
 
 crossVersion := CrossVersion.binary
 
-crossScalaVersions ++= Seq("2.9.2", "2.9.3", "2.10.0")
+crossScalaVersions ++= Seq("2.10.4", "2.11.2")
 
 releaseSettings
-
-scalariformSettings
 
 ivyXML :=
     <dependencies>
@@ -32,7 +30,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "org.mockito" % "mockito-all" % "1.8.5" % "test",
   "org.slf4j" % "slf4j-simple" % "1.6.1" % "test",
-  "org.scalatest" %% "scalatest" % "1.9.2" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
 
 publishTo <<= (version) { version: String =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2-RC2
+sbt.version=0.13.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
-addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.4.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,16 @@
+
+#!/bin/bash
+
+#####################################################
+#
+# Used to provision the Vagrant VM
+#
+#####################################################
+
+wget http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb
+sudo dpkg -i sbt-0.13.5.deb
+sudo apt-get update
+
+sudo apt-get install -y  -o "Acquire::http::Timeout=900" openjdk-7-jdk
+
+sudo apt-get install -y sbt

--- a/src/test/scala/com.gu.conf/GuardianConfigurationStrategyTest.scala
+++ b/src/test/scala/com.gu.conf/GuardianConfigurationStrategyTest.scala
@@ -18,11 +18,10 @@ package com.gu.conf
 import com.gu.conf.fixtures.PropertiesBuilder
 import com.gu.conf.impl._
 import org.mockito.Mockito.when
-import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ BeforeAndAfter, FunSuite }
+import org.scalatest.{Matchers, BeforeAndAfter, FunSuite}
 
-class GuardianConfigurationStrategyTest extends FunSuite with ShouldMatchers with MockitoSugar with BeforeAndAfter {
+class GuardianConfigurationStrategyTest extends FunSuite with Matchers with MockitoSugar with BeforeAndAfter {
 
   val SETUP_PROPERTIES = "file:/etc/gu/setup.properties"
 

--- a/src/test/scala/com.gu.conf/impl/AbstractConfigurationTestBase.scala
+++ b/src/test/scala/com.gu.conf/impl/AbstractConfigurationTestBase.scala
@@ -15,10 +15,9 @@
  */
 package com.gu.conf.impl
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{Matchers, FunSuite}
 
-trait AbstractConfigurationTestBase extends FunSuite with ShouldMatchers {
+trait AbstractConfigurationTestBase extends FunSuite with Matchers {
 
   var configuration: AbstractConfiguration = _
 
@@ -75,13 +74,13 @@ trait AbstractConfigurationTestBase extends FunSuite with ShouldMatchers {
   }
 
   test("should throw for integer property if not integer") {
-    evaluating {
+    an [NumberFormatException] should be thrownBy {
       configuration.getIntegerProperty("double.property")
-    } should produce[NumberFormatException]
+    }
 
-    evaluating {
+    an [NumberFormatException] should be thrownBy  {
       configuration.getIntegerProperty("nonnumeric.property")
-    } should produce[NumberFormatException]
+    }
   }
 
   test("should get default for integer property if not set") {

--- a/src/test/scala/com.gu.conf/impl/IdeologicalPurityTest.scala
+++ b/src/test/scala/com.gu.conf/impl/IdeologicalPurityTest.scala
@@ -16,9 +16,9 @@
 package com.gu.conf.impl
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-class IdeologicalPurityTest extends FunSuite with ShouldMatchers {
+class IdeologicalPurityTest extends FunSuite with Matchers {
 
   implicit def shouldBe2Is(actual: String) = new {
     def is(expected: String) = new StringShouldWrapper(actual) should be(expected)

--- a/src/test/scala/com.gu.conf/impl/PropertiesLoaderTest.scala
+++ b/src/test/scala/com.gu.conf/impl/PropertiesLoaderTest.scala
@@ -16,10 +16,10 @@
 package com.gu.conf.impl
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import java.io.File
 
-class PropertiesLoaderTest extends FunSuite with ShouldMatchers {
+class PropertiesLoaderTest extends FunSuite with Matchers {
   val loader = new PropertiesLoader
   val basedir = "file:" + new File(".").getAbsolutePath
 

--- a/src/test/scala/com.gu.conf/impl/SetupConfigurationTest.scala
+++ b/src/test/scala/com.gu.conf/impl/SetupConfigurationTest.scala
@@ -19,10 +19,10 @@ import com.gu.conf.fixtures.PropertiesBuilder
 import java.util.Properties
 import org.mockito.Mockito.when
 import org.scalatest.{ FunSuite, BeforeAndAfter }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
 
-class SetupConfigurationTest extends FunSuite with ShouldMatchers with MockitoSugar with BeforeAndAfter {
+class SetupConfigurationTest extends FunSuite with Matchers with MockitoSugar with BeforeAndAfter {
 
   var loader = mock[PropertiesLoader]
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "3.11-SNAPSHOT"
+version in ThisBuild := "4.1-SNAPSHOT"


### PR DESCRIPTION
Kept Scala 2.10.4, but dropped older versions of Scala.

Also added a Vagrant which you can optionally use for development (had some issues as I don't have Java 7 installed).

I have already done a 4.0 release.
