### PR TITLE
stop it logging the whole conf file every time

### DIFF
--- a/src/main/scala/com.gu.conf/ConfigurationFactory.scala
+++ b/src/main/scala/com.gu.conf/ConfigurationFactory.scala
@@ -32,24 +32,8 @@ object ConfigurationFactory {
   def getConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
     (new GuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
   }
-}
 
-object NonLoggingConfigurationFactory {
-
-  def apply(applicationName: String): Configuration = {
-    getConfiguration(applicationName)
-  }
-
-  def apply(applicationName: String, webappConfDirectory: String): Configuration = {
-    getConfiguration(applicationName, webappConfDirectory)
-  }
-
-  def getConfiguration(applicationName: String): Configuration = {
-    getConfiguration(applicationName, "conf")
-  }
-
-  def getConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
-    (new NonLoggingGuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
+  def getNonLoggingConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
+    (new GuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
   }
 }
-

--- a/src/main/scala/com.gu.conf/ConfigurationFactory.scala
+++ b/src/main/scala/com.gu.conf/ConfigurationFactory.scala
@@ -33,3 +33,23 @@ object ConfigurationFactory {
     (new GuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
   }
 }
+
+object NonLoggingConfigurationFactory {
+
+  def apply(applicationName: String): Configuration = {
+    getConfiguration(applicationName)
+  }
+
+  def apply(applicationName: String, webappConfDirectory: String): Configuration = {
+    getConfiguration(applicationName, webappConfDirectory)
+  }
+
+  def getConfiguration(applicationName: String): Configuration = {
+    getConfiguration(applicationName, "conf")
+  }
+
+  def getConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
+    (new NonLoggingGuardianConfigurationStrategy).getConfiguration(applicationName, webappConfDirectory)
+  }
+}
+

--- a/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
+++ b/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
@@ -39,11 +39,7 @@ private[conf] class GuardianConfigurationStrategy(
       getDeveloperCommonProperties(webappConfDirectory),
       getEnvironmentProperties)
 
-    val placeholderProcessed = new PlaceholderProcessingConfiguration(properties)
-
-    LOG.info("Configured webapp {} with properties:\n\n{}", applicationName, placeholderProcessed)
-
-    placeholderProcessed
+    new PlaceholderProcessingConfiguration(properties)
   }
 
   def getDeveloperAccountOverrideProperties(applicationName: String) = {

--- a/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
+++ b/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
@@ -25,11 +25,16 @@ private[conf] class GuardianConfigurationStrategy(
     val setup: SetupConfiguration = new SetupConfiguration) {
 
   private final val LOG: Logger = LoggerFactory.getLogger(classOf[GuardianConfigurationStrategy])
+  val shouldLog: Boolean = true
 
-  LOG.info("INT_SERVICE_DOMAIN: " + setup.getServiceDomain)
+  def log(message: String, objects: Object*) {
+    if (shouldLog) {
+      LOG.info(message, objects)
+    }
+  }
 
   def getConfiguration(applicationName: String, webappConfDirectory: String): Configuration = {
-    LOG.info("Configuring application {} using classpath configuration directory {}", applicationName, webappConfDirectory)
+    log("Configuring application {} using classpath configuration directory {}", applicationName, webappConfDirectory)
 
     val properties = CompositeConfiguration.from(
       getDeveloperAccountOverrideProperties(applicationName),
@@ -46,7 +51,7 @@ private[conf] class GuardianConfigurationStrategy(
     val home = System getProperty "user.home"
     val location = "file://%s/.gu/%s.properties".format(home, applicationName)
 
-    LOG.info("Loading developer account override properties from " + location)
+    log("Loading developer account override properties from " + location)
     val properties = loader getPropertiesFrom location
 
     new PropertiesBasedConfiguration(location, properties)
@@ -55,7 +60,7 @@ private[conf] class GuardianConfigurationStrategy(
   def getOperationsProperties(applicationName: String) = {
     val location = "file:///etc/gu/%s.properties" format applicationName
 
-    LOG.info("Loading operations properties from " + location)
+    log("Loading operations properties from " + location)
     val properties = loader getPropertiesFrom location
 
     new PropertiesBasedConfiguration(location, properties)
@@ -65,7 +70,7 @@ private[conf] class GuardianConfigurationStrategy(
     val stage = setup.getStage
     val location = "classpath:%s/%s.properties".format(confPrefix, stage)
 
-    LOG.info("Loading developer stage based properties from " + location)
+    log("Loading developer stage based properties from " + location)
     val properties = loader getPropertiesFrom location
 
     new PropertiesBasedConfiguration(location, properties)
@@ -75,7 +80,7 @@ private[conf] class GuardianConfigurationStrategy(
     val serviceDomain = setup.getServiceDomain
     val location = String.format("classpath:%s/%s.properties", confPrefix, serviceDomain)
 
-    LOG.info("Loading developer service domain based properties from " + location)
+    log("Loading developer service domain based properties from " + location)
     val properties = loader getPropertiesFrom location
 
     new PropertiesBasedConfiguration(location, properties)
@@ -84,19 +89,27 @@ private[conf] class GuardianConfigurationStrategy(
   def getDeveloperCommonProperties(webappConfDirectory: String) = {
     val location = "classpath:%s/global.properties" format webappConfDirectory
 
-    LOG.info("Loading developer common properties from " + location)
+    log("Loading developer common properties from " + location)
     val properties = loader getPropertiesFrom location
 
     new PropertiesBasedConfiguration(location, properties)
   }
 
   def getEnvironmentProperties = {
-    LOG.info("Loading system environment variables")
+    log("Loading system environment variables")
     val props = new Properties()
 
     setup.getEnvironmentVariables.foreach { pair => props.setProperty(pair._1, pair._2) }
 
     new PropertiesBasedConfiguration("Environment", props)
   }
+
+}
+
+private[conf] class NonLoggingGuardianConfigurationStrategy(
+    override val loader: PropertiesLoader = new PropertiesLoader,
+    override val setup: SetupConfiguration = new SetupConfiguration) extends GuardianConfigurationStrategy(loader, setup) {
+
+  override val shouldLog: Boolean = false
 
 }

--- a/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
+++ b/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
@@ -22,10 +22,10 @@ import java.util.Properties
 
 private[conf] class GuardianConfigurationStrategy(
     val loader: PropertiesLoader = new PropertiesLoader,
-    val setup: SetupConfiguration = new SetupConfiguration) {
+    val setup: SetupConfiguration = new SetupConfiguration,
+    val shouldLog: Boolean = true) {
 
   private final val LOG: Logger = LoggerFactory.getLogger(classOf[GuardianConfigurationStrategy])
-  val shouldLog: Boolean = true
 
   def log(message: String, objects: Object*) {
     if (shouldLog) {
@@ -103,13 +103,5 @@ private[conf] class GuardianConfigurationStrategy(
 
     new PropertiesBasedConfiguration("Environment", props)
   }
-
-}
-
-private[conf] class NonLoggingGuardianConfigurationStrategy(
-    override val loader: PropertiesLoader = new PropertiesLoader,
-    override val setup: SetupConfiguration = new SetupConfiguration) extends GuardianConfigurationStrategy(loader, setup) {
-
-  override val shouldLog: Boolean = false
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "4.1-SNAPSHOT"
+version in ThisBuild := "4.2-SNAPSHOT"


### PR DESCRIPTION
In the frontend root test run, before many tests we get a huge file logged.  Not sure if I should have just stripped back or reduced the log level of the log line, but I'll go for a complete removal for now.

@rich-nguyen I assume this is the log spam you weren't keen on?