### PR TITLE
chore: remove unused resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,11 +39,6 @@ ivyXML :=
         <exclude module="log4j"/>
     </dependencies>
 
-resolvers ++= Seq(
-  "Scala Tools Repository" at "https://scala-tools.org/repo-releases",
-  "Guardian GitHub" at "https://guardian.github.com/maven/repo-releases"
-)
-
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "1.4",
   "commons-lang" % "commons-lang" % "2.4",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As a result of MavenGate, we are removing sbt resolvers that are not owned by Sonatype. This PR removes 2 unused resolvers.

## How to test

Running `sbt clean compile test` locally completed successfully and all tests passed.
