### PR TITLE
Upgrade to scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/plugins/boot
 .bsp/
 .metals/
 .vscode/
+test-results/

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ releaseProcess := Seq[ReleaseStep](
 )
 releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
-scalaVersion := "2.12.19"
+scalaVersion := "2.13.14"
 
 ivyXML :=
     <dependencies>

--- a/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
+++ b/src/main/scala/com.gu.conf/GuardianConfigurationStrategy.scala
@@ -27,7 +27,7 @@ private[conf] class GuardianConfigurationStrategy(
 
   private final val LOG: Logger = LoggerFactory.getLogger(classOf[GuardianConfigurationStrategy])
 
-  def log(message: String, objects: Object*) {
+  def log(message: String, objects: Object*): Unit = {
     if (shouldLog) {
       LOG.info(message, objects)
     }

--- a/src/main/scala/com.gu.conf/impl/PropertiesBasedConfiguration.scala
+++ b/src/main/scala/com.gu.conf/impl/PropertiesBasedConfiguration.scala
@@ -16,8 +16,8 @@
 package com.gu.conf.impl
 
 import java.util.Properties
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 private[conf] class PropertiesBasedConfiguration(
   private val _identifier: String,
-  private val _properties: Properties) extends MapBasedConfiguration(_identifier, _properties.toMap)
+  private val _properties: Properties) extends MapBasedConfiguration(_identifier, _properties.asScala.toMap)

--- a/src/main/scala/com.gu.conf/impl/SetupConfiguration.scala
+++ b/src/main/scala/com.gu.conf/impl/SetupConfiguration.scala
@@ -58,8 +58,8 @@ private[conf] class SetupConfiguration(
   def getPropertyNames: Set[String] = setup.getPropertyNames
 
   def getEnvironmentVariables: Map[String, String] = {
-    import scala.collection.JavaConversions._
-    System.getenv.toMap
+    import scala.jdk.CollectionConverters._
+    System.getenv.asScala.toMap
   }
 
   override def toString(): String = setup.toString()

--- a/src/main/scala/com.gu.conf/impl/SystemConfigurations.scala
+++ b/src/main/scala/com.gu.conf/impl/SystemConfigurations.scala
@@ -16,10 +16,10 @@
 package com.gu.conf.impl
 
 import java.util.Properties
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 private[conf] object SystemEnvironmentConfiguration {
-  val environment = System.getenv().toMap
+  val environment = System.getenv().asScala.toMap
 }
 
 private[conf] class SystemEnvironmentConfiguration(

--- a/src/main/scala/com.gu.conf/vfs/ClasspathFileProvider.scala
+++ b/src/main/scala/com.gu.conf/vfs/ClasspathFileProvider.scala
@@ -18,7 +18,7 @@ package com.gu.conf.vfs
 import org.apache.commons.vfs2.provider.AbstractFileProvider
 import org.apache.commons.vfs2.provider.UriParser
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import org.apache.commons.vfs2._
 
 class ClasspathFileProvider extends AbstractFileProvider {
@@ -42,8 +42,8 @@ class ClasspathFileProvider extends AbstractFileProvider {
     ClasspathFileSystemConfigBuilder.instance
   }
 
-  override def closeFileSystem(filesystem: FileSystem) {
+  override def closeFileSystem(filesystem: FileSystem): Unit = {
   }
 
-  def getCapabilities: java.util.Collection[Capability] = Set(Capability.DISPATCHER)
+  def getCapabilities: java.util.Collection[Capability] = Set(Capability.DISPATCHER).asJava
 }

--- a/src/main/scala/com.gu.conf/vfs/ClasspathFileSystemConfigBuilder.scala
+++ b/src/main/scala/com.gu.conf/vfs/ClasspathFileSystemConfigBuilder.scala
@@ -23,7 +23,7 @@ import org.apache.commons.vfs2.provider.url.UrlFileSystem
 object ClasspathFileSystemConfigBuilder {
   lazy val instance: ClasspathFileSystemConfigBuilder = new ClasspathFileSystemConfigBuilder
 
-  def setClassLoader(opts: FileSystemOptions, classLoader: ClassLoader) {
+  def setClassLoader(opts: FileSystemOptions, classLoader: ClassLoader): Unit = {
     instance.setClassLoader(opts, classLoader)
   }
 
@@ -35,7 +35,7 @@ object ClasspathFileSystemConfigBuilder {
 class ClasspathFileSystemConfigBuilder extends FileSystemConfigBuilder("classpath.") {
   private val CLASSLOADER_OPTION_NAME = classOf[ClassLoader].getName
 
-  def setClassLoader(opts: FileSystemOptions, classLoader: ClassLoader) {
+  def setClassLoader(opts: FileSystemOptions, classLoader: ClassLoader): Unit = {
     setParam(opts, CLASSLOADER_OPTION_NAME, classLoader)
   }
 

--- a/src/test/scala/com.gu.conf/impl/SystemPropertiesConfigurationTest.scala
+++ b/src/test/scala/com.gu.conf/impl/SystemPropertiesConfigurationTest.scala
@@ -16,7 +16,6 @@
 package com.gu.conf.impl
 
 import org.scalatest.BeforeAndAfter
-import scala.collection.JavaConversions._
 
 class SystemPropertiesConfigurationTest extends AbstractConfigurationTestBase with BeforeAndAfter {
   before {
@@ -40,7 +39,7 @@ class SystemPropertiesConfigurationTest extends AbstractConfigurationTestBase wi
         System.setProperty(key, value)
     }
 
-    configuration = new ProjectedConfiguration(new SystemPropertiesConfiguration, properties.keySet.toSet)
+    configuration = new ProjectedConfiguration(new SystemPropertiesConfiguration, properties.keySet)
   }
 
   after {


### PR DESCRIPTION
## What does this change?

Upgrades Scala from 2.12.19 to 2.13.14.  This required new imports for converting between Scala and Java collections. We have also resolved warning about deprecated procedure syntax.

## How to test

* Release library
* Upgrade project depending on the library