### PR TITLE
CVE-2020-36518 : Exclude hadoop as we don't use it

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ ivyXML :=
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.16.1",
   "commons-lang" % "commons-lang" % "2.6",
-  "org.apache.commons" % "commons-vfs2" % "2.9.0",
+  "org.apache.commons" % "commons-vfs2" % "2.9.0" exclude("org.apache.hadoop", "hadoop-hdfs-client"),
   "org.slf4j" % "slf4j-api" % "1.6.6",
   "org.scalatestplus" %% "mockito-5-10" % "3.2.18.0" % Test,
   "org.slf4j" % "slf4j-simple" % "1.6.6" % Test,


### PR DESCRIPTION
We noticed that there was a security notification for a newly added very old version of jackson-databind
https://nvd.nist.gov/vuln/detail/CVE-2020-36518

This turns out to be from the new version of vfs2 which pulls in a hadoop HDFS library that should be optional (and will be in future) https://github.com/apache/commons-vfs/pull/291

This PR excludes the hadoop dependency as we don't need it, thus removing the jackson-databind transitive dependency.

Before:
```
[IJ]dependencyTree
[info] com.gu:configuration_2.13:4.4.4-SNAPSHOT [S]
[info]   +-commons-io:commons-io:2.16.1
[info]   +-commons-lang:commons-lang:2.6
[info]   +-org.apache.commons:commons-vfs2:2.9.0
[info]   | +-commons-logging:commons-logging:1.2
[info]   | +-org.apache.commons:commons-lang3:3.12.0
[info]   | +-org.apache.hadoop:hadoop-hdfs-client:3.3.1
[info]   |   +-com.fasterxml.jackson.core:jackson-annotations:2.10.5
[info]   |   +-com.fasterxml.jackson.core:jackson-databind:2.10.5.1
[info]   |   | +-com.fasterxml.jackson.core:jackson-annotations:2.10.5
[info]   |   | +-com.fasterxml.jackson.core:jackson-core:2.10.5
[info]   |   | 
[info]   |   +-com.squareup.okhttp:okhttp:2.7.5
[info]   |     +-com.squareup.okio:okio:1.6.0
[info]   |     
[info]   +-org.slf4j:slf4j-api:1.6.6
```
After
```
[IJ]dependencyTree
[info] com.gu:configuration_2.13:4.4.4-SNAPSHOT [S]
[info]   +-commons-io:commons-io:2.16.1
[info]   +-commons-lang:commons-lang:2.6
[info]   +-org.apache.commons:commons-vfs2:2.9.0
[info]   | +-commons-logging:commons-logging:1.2
[info]   | +-org.apache.commons:commons-lang3:3.12.0
[info]   | 
[info]   +-org.slf4j:slf4j-api:1.6.6
```