### PR TITLE
Explicitly use version v1 of gha-scala-library-release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}


### PR DESCRIPTION
See https://github.com/guardian/gha-scala-library-release-workflow/pull/61